### PR TITLE
Position control zero position bugfixes and features

### DIFF
--- a/BrushedMotorControllerFirmware/Kconfig
+++ b/BrushedMotorControllerFirmware/Kconfig
@@ -58,7 +58,7 @@ config POSITION_CONTROL_MODIFIER
 config POS_CONTROL_MIN_SPEED_MODIFIER
 	int "divider for minimal speed during position control. \
 	     Max speed is taken and divied by this value"
-	default 12
+	default 16
 
 config POS_CONTROL_PRECISION_MODIFIER
 	int "divider for precision of position control.\

--- a/BrushedMotorControllerFirmware/include/driver.c
+++ b/BrushedMotorControllerFirmware/include/driver.c
@@ -67,7 +67,8 @@ struct DriverChannel {
 	uint32_t curr_pos;
 	uint32_t target_position;
 
-	int32_t position_delta;//TEMP
+	int32_t position_delta; //TEMP
+	// I think it can be turned into local variable only in method that uses it?
 
 	const uint32_t max_pos;
 
@@ -553,6 +554,26 @@ return_codes_t mode_get(enum ControlModes *value)
 	}
 
 	*value = control_mode;
+	return SUCCESS;
+}
+
+return_codes_t position_reset_zero(enum ChannelNumber chnl)
+{
+	if (!drv_initialised) {
+		return ERR_NOT_INITIALISED;
+	}
+
+	if (control_mode != POSITION) {
+		return ERR_UNSUPPORTED_FUNCTION_IN_CURRENT_MODE;
+	}
+
+	if (drv_chnls[chnl].actual_dir != STOPPED) {
+		return ERR_MOTOR_SHOULD_BE_STATIONARY;
+	}
+
+	drv_chnls[chnl].curr_pos = 0;
+	drv_chnls[chnl].target_position = 0;
+
 	return SUCCESS;
 }
 

--- a/BrushedMotorControllerFirmware/include/driver.c
+++ b/BrushedMotorControllerFirmware/include/driver.c
@@ -220,16 +220,22 @@ static void update_speed_and_position_continuous(struct k_work *work)
 						set_direction_raw(FORWARD, chnl);
 				}
 
-				// TODO - it has issues with keeping "0" position, improve!
-				if (drv_chnls[chnl].position_delta >
+				if (drv_chnls[chnl].position_delta <=
 						(FULL_SPIN_DEGREES) /
-						(CONFIG_POS_CONTROL_PRECISION_MODIFIER)) {
+						(CONFIG_POS_CONTROL_PRECISION_MODIFIER)
+				    ||
+				    (FULL_SPIN_DEGREES - drv_chnls[chnl].position_delta) <=
+						(FULL_SPIN_DEGREES) /
+						(CONFIG_POS_CONTROL_PRECISION_MODIFIER)
+				   ) {
+					// if position_delta is small enough, or large enough that
+					// it is actually small "from other side"
+					drv_chnls[chnl].target_speed_mrpm = 0;
+				} else {
 					// TODO - add actual PID! (instead of slow spinning!)
 					drv_chnls[chnl].target_speed_mrpm =
 						CONFIG_SPEED_MAX_MRPM /
 						CONFIG_POS_CONTROL_MIN_SPEED_MODIFIER;
-				} else {
-					drv_chnls[chnl].target_speed_mrpm = 0;
 				}
 				ret_debug = speed_pwm_set(drv_chnls[chnl].target_speed_mrpm, chnl);
 			}

--- a/BrushedMotorControllerFirmware/include/driver.h
+++ b/BrushedMotorControllerFirmware/include/driver.h
@@ -46,21 +46,21 @@ void init_pwm_motor_driver(void);
 
 /// @brief Set new desired (targeted) speed AND set the pwm
 /// @param value - value in mili RPM
-/// @return error defined in error_codes
+/// @return error defined in return_codes.h
 return_codes_t target_speed_set(uint32_t value, enum ChannelNumber chnl);
 
 /// @brief Get current actual speed (from encoders)  - TODO - implement with encoders
 /// @param value - variable to save speed
-/// @return error defined in error_codes
+/// @return error defined in return_codes.h
 return_codes_t speed_get(enum ChannelNumber chnl, uint32_t *value);
 
 /// @brief Turn motor on in proper direction, without modyfing target speed or set pwm output.
 /// @param direction - FORWARD or BACKWARD
-/// @return error defined in error_codes
+/// @return error defined in return_codes.h
 return_codes_t motor_on(enum MotorDirection direction, enum ChannelNumber chnl);
 
 /// @brief Turn motor off, without modyfing pwm output
-/// @return error defined in error_codes
+/// @return error defined in return_codes.h
 return_codes_t motor_off(enum ChannelNumber chnl);
 
 /// @brief Simple getter for max speed (set by init_pwm_motor_driver)
@@ -74,7 +74,7 @@ bool get_motor_off_on(enum ChannelNumber chnl);
 /// @brief getter for spinning direction calculated based on encoder feedback
 /// @param  channel number for direction
 /// @param  output - spinning direction
-/// @return code defined in error_codes
+/// @return code defined in return_codes.h
 int get_motor_actual_direction(enum ChannelNumber chnl, enum MotorDirection *out_dir);
 
 /// @brief Simple getter for firmware software version
@@ -88,13 +88,13 @@ uint32_t speed_target_get(enum ChannelNumber chnl);
 /// @brief utility function for converting control mode as string to control mode as proper enum
 /// @param str_control_mode control mode as string
 /// @param ret_value output - control mode as control mode enum
-/// @return error defined in error_codes
+/// @return error defined in return_codes.h
 return_codes_t get_control_mode_from_string(char *str_control_mode, enum ControlModes *ret_value);
 
 /// @brief utility function for converting control mode from enum to string
 /// @param control_mode control mode as enum
 /// @param ret_value output - control mode as string
-/// @return error defined in error_codes
+/// @return error defined in return_codes.h
 return_codes_t get_control_mode_as_string(enum ControlModes control_mode, char **ret_value);
 
 return_codes_t target_position_set(uint32_t new_target_position, enum ChannelNumber chnl);
@@ -104,6 +104,11 @@ return_codes_t position_get(uint32_t *value, enum ChannelNumber chnl);
 return_codes_t mode_set(enum ControlModes new_mode);
 
 return_codes_t mode_get(enum ControlModes *value);
+
+/// @brief reset zero position to current position.
+/// @param chnl - channel, for which should it be reset
+/// @return error defined in return_codes.h
+return_codes_t position_reset_zero(enum ChannelNumber chnl);
 
 #if defined(CONFIG_BOARD_NRF52840DONGLE_NRF52840)
 /// @brief Enter bootloader mode (in order to flash new software via nRF connect programmer)

--- a/BrushedMotorControllerFirmware/include/return_codes.h
+++ b/BrushedMotorControllerFirmware/include/return_codes.h
@@ -13,6 +13,7 @@ typedef enum {
 	ERR_TOO_MANY_TEMPLATES_DEFINED = 3,
 	ERR_COULDNT_FIND_TEMPLATE = 4,
 	ERR_EMPTY_TEMPLATE_LIST = 5,
+	ERR_MOTOR_SHOULD_BE_STATIONARY = 5,
 
 	// Critical errors (16+) - Are result of serious hardware issue
 	ERR_NOT_INITIALISED = 16,

--- a/BrushedMotorControllerFirmware/include/uart_shell/shell_direct_motor_control.c
+++ b/BrushedMotorControllerFirmware/include/uart_shell/shell_direct_motor_control.c
@@ -93,6 +93,22 @@ static int cmd_position(const struct shell *shell, size_t argc, char *argv[])
 	return 0;
 }
 
+static int cmd_position_zero(const struct shell *shell, size_t argc, char *argv[])
+{
+	return_codes_t ret;
+
+	ret = position_reset_zero(get_relevant_channel());
+
+	if (ret == SUCCESS) {
+		shell_fprintf(shell, SHELL_NORMAL, "Position reset succesfulll\n");
+
+	} else {
+		shell_fprintf(shell, SHELL_ERROR, "Error, code: %d!\n", ret);
+	}
+
+	return 0;
+}
+
 static int cmd_mode(const struct shell *shell, size_t argc, char *argv[])
 {
 	return_codes_t ret;
@@ -176,7 +192,12 @@ SHELL_CMD_ARG_REGISTER(speed, NULL,
 	"speed in milli RPM (one thousands of RPM)\nspeed to get speed\n speed <val> to set speed",
 	cmd_speed, 1, 1);
 
-SHELL_CMD_ARG_REGISTER(pos, NULL, "get/set position in deca-degree", cmd_position, 1, 1);
+SHELL_STATIC_SUBCMD_SET_CREATE(position_tree,
+SHELL_CMD(zero,       NULL, "Zero position to current position", cmd_position_zero),
+SHELL_SUBCMD_SET_END
+);
+
+SHELL_CMD_ARG_REGISTER(pos, &position_tree, "get/set position in deca-degree", cmd_position, 1, 1);
 SHELL_CMD_ARG_REGISTER(mode, NULL, "choose mode, pos/speed control. Default speed", cmd_mode, 1, 1);
 
 SHELL_CMD_REGISTER(actual_direction, NULL, "get motor actual spinning direction",


### PR DESCRIPTION
1. Bugfix - quick movement changes forward/backward caused position "zero" to move
   * direction calculation moved to timer interrupt
   * enc interrupt accumulator separated to forward interrupts and backward interrupts
2. Feature added - reset zero to current position
3. Bugfix - keeping position zero (added calculation if negative tolerance for keeping position is below zero)
4. Maitnance - position control universal max position (full spin - 360 deg) moved to define