### PR TITLE
Proportional regulator with hysteresis introduced for position control

### DIFF
--- a/BrushedMotorControllerFirmware/Kconfig
+++ b/BrushedMotorControllerFirmware/Kconfig
@@ -50,15 +50,25 @@ config KP_DENOMINATOR_FOR_SPEED
 	int "proportional part denominator for speed control"
 	default 10
 
+config KP_NUMERATOR_FOR_SPEED_IN_POS
+	int "proportional part numerator for setting speed during position control"
+	default 4
+
+config KP_DENOMINATOR_FOR_SPEED_IN_POS
+	int "proportional part denominator for setting speed during position control"
+	default 100
+
 config POSITION_CONTROL_MODIFIER
 	int "Accuracy of position control (if value is 10 position is controlled in deca-degrees; \
 	     if 100 - centi-degrees etc.)"
 	default 100
 
-config POS_CONTROL_MIN_SPEED_MODIFIER
-	int "divider for minimal speed during position control. \
-	     Max speed is taken and divied by this value"
-	default 16
+config MIN_SPEED_MODIFIER
+	int "divider for minimal speed. \
+	     Max speed is taken and divied by this value \
+	     used as minimum RPM value that can be set, RPMs lower than that will be treated as \
+	     zero. Also, it is used as minimum speed during position control."
+	default 28
 
 config POS_CONTROL_PRECISION_MODIFIER
 	int "divider for precision of position control.\

--- a/BrushedMotorControllerFirmware/Kconfig
+++ b/BrushedMotorControllerFirmware/Kconfig
@@ -56,7 +56,15 @@ config KP_NUMERATOR_FOR_SPEED_IN_POS
 
 config KP_DENOMINATOR_FOR_SPEED_IN_POS
 	int "proportional part denominator for setting speed during position control"
-	default 100
+	default 50
+
+config KP_NUMERATOR_FOR_POS
+	int "proportional part numerator for setting speed during position control"
+	default 2
+
+config KP_DENOMINATOR_FOR_POS
+	int "proportional part denominator for setting speed during position control"
+	default 1
 
 config POSITION_CONTROL_MODIFIER
 	int "Accuracy of position control (if value is 10 position is controlled in deca-degrees; \
@@ -74,6 +82,10 @@ config POS_CONTROL_PRECISION_MODIFIER
 	int "divider for precision of position control.\
 	     Ex. 720 means that precision is 360/720 = +-0.5 degree"
 	default 720
+
+config POS_CONTROL_HISTERESIS_PERCENTAGE
+	int "Histeresis percentage of position control. For no histeresis, set to 100."
+	default 100
 
 
 config USB_DEVICE_VID

--- a/BrushedMotorControllerFirmware/include/calculations.h
+++ b/BrushedMotorControllerFirmware/include/calculations.h
@@ -1,9 +1,26 @@
+/* SPDX-License-Identifier: Apache-2.0
+ *
+ * Copyright (c) 2024 Maciej Baczmanski, Jakub Mazur
+ */
 
 #define CALC_SPEED_CONTROL(target_speed, actual_speed) \
-        ((int32_t)( CONFIG_KP_NUMERATOR_FOR_SPEED * (int32_t)(target_speed - actual_speed) / \
-                    CONFIG_KP_DENOMINATOR_FOR_SPEED))
+	((int32_t)(CONFIG_KP_NUMERATOR_FOR_SPEED * (int32_t)(target_speed - actual_speed) / \
+		   CONFIG_KP_DENOMINATOR_FOR_SPEED))
 
 
 #define CALC_SPEED_CONTROL_FOR_POS(target_speed, actual_speed) \
-        ((int32_t)( CONFIG_KP_NUMERATOR_FOR_SPEED_IN_POS * (int32_t)(target_speed - actual_speed) / \
-                    CONFIG_KP_DENOMINATOR_FOR_SPEED_IN_POS))
+	((int32_t)(CONFIG_KP_NUMERATOR_FOR_SPEED_IN_POS * (int32_t)(target_speed - actual_speed) / \
+		   CONFIG_KP_DENOMINATOR_FOR_SPEED_IN_POS))
+
+// Difference from target position and actual position
+#define CALC_POSITION_DELTA(chnl) \
+	drv_chnls[chnl].position_delta = drv_chnls[chnl].target_position - \
+					 drv_chnls[chnl].curr_pos; \
+	bool is_target_behind = false; \
+	if (drv_chnls[chnl].position_delta < 0) { \
+		drv_chnls[chnl].position_delta = \
+		-drv_chnls[chnl].position_delta; \
+		is_target_behind = true; \
+	} \
+// Check if motor should spin backward to get to the target
+// (if target is smalller number than current position)

--- a/BrushedMotorControllerFirmware/include/calculations.h
+++ b/BrushedMotorControllerFirmware/include/calculations.h
@@ -1,0 +1,4 @@
+
+#define CALC_SPEED_CONTROL(target_speed, actual_speed) \
+        ((int32_t)( CONFIG_KP_NUMERATOR_FOR_SPEED * (int32_t)(target_speed - actual_speed) / \
+                    CONFIG_KP_DENOMINATOR_FOR_SPEED))

--- a/BrushedMotorControllerFirmware/include/calculations.h
+++ b/BrushedMotorControllerFirmware/include/calculations.h
@@ -2,3 +2,8 @@
 #define CALC_SPEED_CONTROL(target_speed, actual_speed) \
         ((int32_t)( CONFIG_KP_NUMERATOR_FOR_SPEED * (int32_t)(target_speed - actual_speed) / \
                     CONFIG_KP_DENOMINATOR_FOR_SPEED))
+
+
+#define CALC_SPEED_CONTROL_FOR_POS(target_speed, actual_speed) \
+        ((int32_t)( CONFIG_KP_NUMERATOR_FOR_SPEED_IN_POS * (int32_t)(target_speed - actual_speed) / \
+                    CONFIG_KP_DENOMINATOR_FOR_SPEED_IN_POS))

--- a/BrushedMotorControllerFirmware/include/driver.c
+++ b/BrushedMotorControllerFirmware/include/driver.c
@@ -76,7 +76,7 @@ struct DriverChannel {
 	/// POSITION control
 	uint32_t curr_pos;
 	uint32_t target_position;
-	uint32_t target_speed_for_position_control;
+	uint32_t target_speed_for_pos_cntrl;
 	bool target_achieved;
 	// bool target_achieved_prev_debug;
 
@@ -199,8 +199,8 @@ static void update_speed_and_position_continuous(struct k_work *work)
 						   )
 						  );
 
-				// TODO - currently, this p(id) is more aggresive if CONFIG_ENC_TIMER_PERIOD_MS is
-				// lower. Correct it, make P(ID) only time dependant, not "refresh rate" dependant!
+	// TODO - currently, this p(id) is more aggresive if CONFIG_ENC_TIMER_PERIOD_MS is
+	// lower. Correct it, make P(ID) only time dependent, not "refresh rate" dependent!
 
 				// Cap control at max rpm speed,
 				// to avoid cumulation of too high speeds.
@@ -237,37 +237,23 @@ static void update_speed_and_position_continuous(struct k_work *work)
 
 				drv_chnls[chnl].target_achieved = is_target_achieved(chnl);
 
-				// if(drv_chnls[chnl].target_achieved != drv_chnls[chnl].target_achieved_prev_debug) {
-				// 	printk("ta changed from %d to %d",
-				// 		drv_chnls[chnl].target_achieved_prev_debug,
-				// 		drv_chnls[chnl].target_achieved);
-				// 	printk("shortest path: %d\n", delta_shortest_path);
-				// 	printk("range: %d\n", (FULL_SPIN_DEGREES) / (CONFIG_POS_CONTROL_PRECISION_MODIFIER));
-				// 	printk("range: %d\n", ((FULL_SPIN_DEGREES * CONFIG_POS_CONTROL_HISTERESIS_PERCENTAGE) /
-				// 			(CONFIG_POS_CONTROL_PRECISION_MODIFIER * 100))
-				// 	);
-				// }
-
-				// drv_chnls[chnl].target_achieved_prev_debug = drv_chnls[chnl].target_achieved;
-
 				if (drv_chnls[chnl].target_achieved) {
 					// if position_delta is small enough, or large enough that
 					// it is actually small "from other side"
 					drv_chnls[chnl].target_speed_mrpm = 0;
 				} else {
-					drv_chnls[chnl].target_speed_for_position_control =
+					drv_chnls[chnl].target_speed_for_pos_cntrl =
 						CONFIG_KP_NUMERATOR_FOR_POS * delta_shortest_path /
 						CONFIG_KP_DENOMINATOR_FOR_POS;
 
 					drv_chnls[chnl].target_speed_mrpm =
 						drv_chnls[chnl].target_speed_mrpm +
-						CALC_SPEED_CONTROL_FOR_POS (
-							drv_chnls[chnl].
-								target_speed_for_position_control,
+						CALC_SPEED_CONTROL_FOR_POS(
+							drv_chnls[chnl].target_speed_for_pos_cntrl,
 							drv_chnls[chnl].actual_mrpm
 						);
 
-					if(drv_chnls[chnl].target_speed_mrpm < MINIMUM_SPEED) {
+					if (drv_chnls[chnl].target_speed_mrpm < MINIMUM_SPEED) {
 
 						drv_chnls[chnl].target_speed_mrpm =
 							MINIMUM_SPEED;
@@ -308,8 +294,8 @@ bool is_target_achieved(enum ChannelNumber chnl)
 		}
 	} else {
 		if (delta_shortest_path <=
-		    ((FULL_SPIN_DEGREES * CONFIG_POS_CONTROL_HISTERESIS_PERCENTAGE) /
-		     (CONFIG_POS_CONTROL_PRECISION_MODIFIER * 100))) {
+		   ((FULL_SPIN_DEGREES * CONFIG_POS_CONTROL_HISTERESIS_PERCENTAGE) /
+		    (CONFIG_POS_CONTROL_PRECISION_MODIFIER * 100))) {
 
 			return true;
 		}
@@ -612,7 +598,7 @@ return_codes_t position_get(uint32_t *value, enum ChannelNumber chnl)
 		return ERR_NOT_INITIALISED;
 	}
 
-	if(drv_chnls[chnl].curr_pos == FULL_SPIN_DEGREES) {
+	if (drv_chnls[chnl].curr_pos == FULL_SPIN_DEGREES) {
 		// TODO - remove this when continuus update will treat 360 as 0 as it should!
 		*value = 0u;
 		return SUCCESS;

--- a/BrushedMotorControllerFirmware/include/driver.c
+++ b/BrushedMotorControllerFirmware/include/driver.c
@@ -18,6 +18,8 @@
 
 #define FULL_SPIN_DEGREES (360u * CONFIG_POSITION_CONTROL_MODIFIER)
 
+#define MINIMUM_SPEED (CONFIG_SPEED_MAX_MRPM / CONFIG_MIN_SPEED_MODIFIER)
+
 static const struct DriverVersion driver_ver = {
 	.major = 2,
 	.minor = 2,
@@ -244,21 +246,19 @@ static void update_speed_and_position_continuous(struct k_work *work)
 					// it is actually small "from other side"
 					drv_chnls[chnl].target_speed_mrpm = 0;
 				} else {
-					if(drv_chnls[chnl].target_speed_mrpm <
-					   CONFIG_POS_CONTROL_MIN_SPEED_MODIFIER) {
+					if(drv_chnls[chnl].target_speed_mrpm < MINIMUM_SPEED) {
 
 						drv_chnls[chnl].target_speed_mrpm =
-							CONFIG_POS_CONTROL_MIN_SPEED_MODIFIER;
+							MINIMUM_SPEED;
 					}
 
 					// TODO - add actual PID! (instead of slow spinning!)
 					drv_chnls[chnl].target_speed_mrpm =
 						drv_chnls[chnl].target_speed_mrpm +
-						CALC_SPEED_CONTROL(
-							CONFIG_SPEED_MAX_MRPM /
-							CONFIG_POS_CONTROL_MIN_SPEED_MODIFIER,
+						CALC_SPEED_CONTROL_FOR_POS (
+							MINIMUM_SPEED,
 							drv_chnls[chnl].actual_mrpm
-						)/10;
+						);
 				}
 				ret_debug =
 					speed_pwm_set(drv_chnls[chnl].target_speed_mrpm, chnl);
@@ -496,7 +496,7 @@ static int speed_pwm_set(uint32_t value, enum ChannelNumber chnl)
 		return ERR_DESIRED_VALUE_TO_HIGH;
 	}
 
-	if (drv_chnls[chnl].target_speed_mrpm < CONFIG_POS_CONTROL_MIN_SPEED_MODIFIER) {
+	if (drv_chnls[chnl].target_speed_mrpm < MINIMUM_SPEED) {
 		value = 0;
 		drv_chnls[chnl].speed_control = 0;
 	}

--- a/BrushedMotorControllerFirmware/include/driver.h
+++ b/BrushedMotorControllerFirmware/include/driver.h
@@ -97,7 +97,7 @@ return_codes_t get_control_mode_from_string(char *str_control_mode, enum Control
 /// @return error defined in return_codes.h
 return_codes_t get_control_mode_as_string(enum ControlModes control_mode, char **ret_value);
 
-return_codes_t target_position_set(uint32_t new_target_position, enum ChannelNumber chnl);
+return_codes_t target_position_set(int32_t new_target_position, enum ChannelNumber chnl);
 
 return_codes_t position_get(uint32_t *value, enum ChannelNumber chnl);
 

--- a/BrushedMotorControllerFirmware/include/driver.h
+++ b/BrushedMotorControllerFirmware/include/driver.h
@@ -39,7 +39,6 @@ enum PinNumber {
 	P1
 };
 
-
 /// @brief Function initalising PWMs (drivers) and GPIOs.
 /// @param speed_max_mrpm - max speed defined in mili RPM
 void init_pwm_motor_driver(void);
@@ -98,6 +97,8 @@ return_codes_t get_control_mode_from_string(char *str_control_mode, enum Control
 return_codes_t get_control_mode_as_string(enum ControlModes control_mode, char **ret_value);
 
 return_codes_t target_position_set(int32_t new_target_position, enum ChannelNumber chnl);
+
+bool is_target_achieved(enum ChannelNumber chnl);
 
 return_codes_t position_get(uint32_t *value, enum ChannelNumber chnl);
 

--- a/BrushedMotorControllerFirmware/include/uart_shell/shell_direct_motor_control.c
+++ b/BrushedMotorControllerFirmware/include/uart_shell/shell_direct_motor_control.c
@@ -58,7 +58,7 @@ static int cmd_speed(const struct shell *shell, size_t argc, char *argv[])
 static int cmd_position(const struct shell *shell, size_t argc, char *argv[])
 {
 	return_codes_t ret;
-	uint32_t position;
+	int32_t position;
 
 	if (argc == 1) {
 		ret = position_get(&position, get_relevant_channel());
@@ -71,7 +71,7 @@ static int cmd_position(const struct shell *shell, size_t argc, char *argv[])
 
 		return 0;
 	} else if (argc == 2) {
-		position = (uint32_t)strtol(argv[1], NULL, 10);
+		position = (int32_t)strtol(argv[1], NULL, 10);
 		ret = target_position_set(position, get_relevant_channel());
 		switch (ret) {
 		case (SUCCESS):
@@ -100,7 +100,7 @@ static int cmd_position_zero(const struct shell *shell, size_t argc, char *argv[
 	ret = position_reset_zero(get_relevant_channel());
 
 	if (ret == SUCCESS) {
-		shell_fprintf(shell, SHELL_NORMAL, "Position reset succesfulll\n");
+		shell_fprintf(shell, SHELL_NORMAL, "Position reset succesfull\n");
 
 	} else {
 		shell_fprintf(shell, SHELL_ERROR, "Error, code: %d!\n", ret);
@@ -109,56 +109,7 @@ static int cmd_position_zero(const struct shell *shell, size_t argc, char *argv[
 	return 0;
 }
 
-static int cmd_mode(const struct shell *shell, size_t argc, char *argv[])
-{
-	return_codes_t ret;
-	enum ControlModes mode;
 
-	if (argc == 1) {
-		ret = mode_get(&mode);
-		switch (ret) {
-		case (SUCCESS):
-			char *mode_as_str = "";
-			int r = get_control_mode_as_string(mode, &mode_as_str);
-
-			if (r == SUCCESS) {
-				shell_fprintf(shell, SHELL_NORMAL, "mode: %s\n", mode_as_str);
-
-			} else {
-				shell_fprintf(shell, SHELL_ERROR,
-				"Conversion error, code: %d\n", ret);
-
-			}
-		break;
-		case (ERR_NOT_INITIALISED):
-			shell_fprintf(shell, SHELL_ERROR,
-				"driver not initialised, could't get mode!\n");
-
-		break;
-		default:
-			shell_fprintf(shell, SHELL_ERROR, "other error, code: %d\n", ret);
-		break;
-		}
-
-		return 0;
-	} else if (argc == 2) {
-		ret = get_control_mode_from_string(argv[1], &mode);
-		if (ret != SUCCESS) {
-			shell_fprintf(shell, SHELL_ERROR,
-				"Conversion error, errc: %d\n", ret);
-			return 0;
-		}
-
-		ret = mode_set(mode);
-		if (ret == SUCCESS) {
-			shell_fprintf(shell, SHELL_NORMAL, "mode set to: %s\n", argv[1]);
-
-		} else {
-			shell_fprintf(shell, SHELL_ERROR, "Error, code: %d\n", ret);
-		}
-	}
-	return 0;
-}
 
 static int cmd_actual_direction(const struct shell *shell, size_t argc, char *argv[])
 {
@@ -198,7 +149,6 @@ SHELL_SUBCMD_SET_END
 );
 
 SHELL_CMD_ARG_REGISTER(pos, &position_tree, "get/set position in deca-degree", cmd_position, 1, 1);
-SHELL_CMD_ARG_REGISTER(mode, NULL, "choose mode, pos/speed control. Default speed", cmd_mode, 1, 1);
 
 SHELL_CMD_REGISTER(actual_direction, NULL, "get motor actual spinning direction",
 		   cmd_actual_direction);

--- a/BrushedMotorControllerFirmware/include/uart_shell/shell_mode_control.c
+++ b/BrushedMotorControllerFirmware/include/uart_shell/shell_mode_control.c
@@ -1,0 +1,77 @@
+#if defined(CONFIG_UART_SHELL_SUPPORT)
+
+#include <zephyr/kernel.h>
+#include <zephyr/shell/shell.h>
+#include "driver.h"
+#include "uart_shell/shell_utils.h"
+
+static int cmd_mode(const struct shell *shell, size_t argc, char *argv[])
+{
+	return_codes_t ret;
+	enum ControlModes mode;
+
+	if (argc == 1) {
+		ret = mode_get(&mode);
+		switch (ret) {
+		case (SUCCESS):
+			char *mode_as_str = "";
+			int r = get_control_mode_as_string(mode, &mode_as_str);
+
+			if (r == SUCCESS) {
+				shell_fprintf(shell, SHELL_NORMAL, "mode: %s\n", mode_as_str);
+
+			} else {
+				shell_fprintf(shell, SHELL_ERROR,
+				"Conversion error, code: %d\n", ret);
+
+			}
+		break;
+		case (ERR_NOT_INITIALISED):
+			shell_fprintf(shell, SHELL_ERROR,
+				"driver not initialised, could't get mode!\n");
+
+		break;
+		default:
+			shell_fprintf(shell, SHELL_ERROR, "other error, code: %d\n", ret);
+		break;
+		}
+
+		return 0;
+	}
+
+	return 0;
+}
+
+static int cmd_mode_pos(const struct shell *shell, size_t argc, char *argv[])
+{
+	return_codes_t ret = mode_set(POSITION);
+	if (ret == SUCCESS) {
+		shell_fprintf(shell, SHELL_NORMAL, "mode set to: %s\n", argv[0]);
+
+	} else {
+		shell_fprintf(shell, SHELL_ERROR, "Error, code: %d\n", ret);
+	}
+	return 0;
+}
+
+static int cmd_mode_speed(const struct shell *shell, size_t argc, char *argv[])
+{
+	return_codes_t ret = mode_set(SPEED);
+	if (ret == SUCCESS) {
+		shell_fprintf(shell, SHELL_NORMAL, "mode set to: %s\n", argv[0]);
+
+	} else {
+		shell_fprintf(shell, SHELL_ERROR, "Error, code: %d\n", ret);
+	}
+	return 0;
+}
+
+SHELL_STATIC_SUBCMD_SET_CREATE(mode_tree,
+SHELL_CMD(pos,        NULL, "Set mode to position control", cmd_mode_pos),
+SHELL_CMD(speed,      NULL, "Set mode to speed control", cmd_mode_speed),
+SHELL_SUBCMD_SET_END
+);
+
+SHELL_CMD_ARG_REGISTER(mode, &mode_tree, "choose mode. Default speed", cmd_mode, 1, 0);
+
+#endif

--- a/BrushedMotorControllerFirmware/include/uart_shell/shell_mode_control.c
+++ b/BrushedMotorControllerFirmware/include/uart_shell/shell_mode_control.c
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) 2024 Maciej Baczmanski, Jakub Mazur
+
 #if defined(CONFIG_UART_SHELL_SUPPORT)
 
 #include <zephyr/kernel.h>
@@ -45,6 +48,7 @@ static int cmd_mode(const struct shell *shell, size_t argc, char *argv[])
 static int cmd_mode_pos(const struct shell *shell, size_t argc, char *argv[])
 {
 	return_codes_t ret = mode_set(POSITION);
+
 	if (ret == SUCCESS) {
 		shell_fprintf(shell, SHELL_NORMAL, "mode set to: %s\n", argv[0]);
 
@@ -57,6 +61,7 @@ static int cmd_mode_pos(const struct shell *shell, size_t argc, char *argv[])
 static int cmd_mode_speed(const struct shell *shell, size_t argc, char *argv[])
 {
 	return_codes_t ret = mode_set(SPEED);
+
 	if (ret == SUCCESS) {
 		shell_fprintf(shell, SHELL_NORMAL, "mode set to: %s\n", argv[0]);
 


### PR DESCRIPTION
Mode Control:
1. Uart control moved to separate file, mode setting split to tree
2. Speed control increase calculation moved to separate file
3. Position control is wrapped to range 0-360, so negative numbers and number higher than 360 degrees are accepted, but are wrapped to range
4. Position control now forces given speed, if motor is running too slow

Minimum speed calculation
1. bugfix, minimum speed is actually calculated, modifier is no longer treated as minimum speed
2. speed PID for pos control separated from speed control

PID controller added for position control
1. PID - speed is proportional to distance
2. Optional histeresis added - if target achieved, and falls out of range, but is still in histeresis range, it is still treated as in range