### PR TITLE
PID bugfixes, cleanup and features

### DIFF
--- a/BrushedMotorControllerFirmware/Kconfigs/Kconfig.position_cntrl
+++ b/BrushedMotorControllerFirmware/Kconfigs/Kconfig.position_cntrl
@@ -30,4 +30,9 @@ config POS_CONTROL_HISTERESIS_PERCENTAGE
 	int "Histeresis percentage of position control. For no histeresis, set to 100."
 	default 100
 
+config POS_SOFT_START
+	bool "Speed during position control will incrementally start from zero. If false,\
+	will immediately start from given speed."
+	default y
+
 endmenu

--- a/BrushedMotorControllerFirmware/include/calculations.h
+++ b/BrushedMotorControllerFirmware/include/calculations.h
@@ -3,14 +3,96 @@
  * Copyright (c) 2024 Maciej Baczmanski, Jakub Mazur
  */
 
-#define CALC_SPEED_CONTROL(target_speed, actual_speed) \
-	((int32_t)(CONFIG_KP_NUMERATOR_FOR_SPEED * (int32_t)(target_speed - actual_speed) / \
-		   CONFIG_KP_DENOMINATOR_FOR_SPEED))
 
+struct PID_def {
+	const uint32_t Kp_numerator;
+	const uint32_t Kp_denominator;
 
-#define CALC_SPEED_CONTROL_FOR_POS(target_speed, actual_speed) \
-	((int32_t)(CONFIG_KP_NUMERATOR_FOR_SPEED_IN_POS * (int32_t)(target_speed - actual_speed) / \
-		   CONFIG_KP_DENOMINATOR_FOR_SPEED_IN_POS))
+	const uint32_t Ki_numerator;
+	const uint32_t Ki_denominator;
+
+	const uint32_t Kd_numerator;
+	const uint32_t Kd_denominator;
+
+	int32_t i_temp; // error accumulator
+	int32_t d_temp; // prev error
+
+	int32_t i_min;
+	int32_t i_max;
+};
+
+struct PID_def PID_spd_for_pos = {
+	.Kp_numerator = CONFIG_KP_NUMERATOR_FOR_SPEED_IN_POS,
+	.Kp_denominator = CONFIG_KP_DENOMINATOR_FOR_SPEED_IN_POS,
+
+	.Ki_numerator = 0,
+	.Ki_denominator = 1,
+
+	.Kd_numerator = 0,
+	.Kd_denominator = 1,
+
+	.i_temp = 0,
+	.d_temp = 0,
+
+	.i_min = -1000,
+	.i_max = 5000,
+};
+
+struct PID_def PID_spd = {
+	.Kp_numerator = CONFIG_KP_NUMERATOR_FOR_SPEED,
+	.Kp_denominator = CONFIG_KP_DENOMINATOR_FOR_SPEED,
+
+	.Ki_numerator = 0,
+	.Ki_denominator = 1,
+
+	.Kd_numerator = 0,
+	.Kd_denominator = 1,
+
+	.i_temp = 0,
+	.d_temp = 0,
+
+	.i_min = -1000,
+	.i_max = 5000,
+};
+
+struct PID_def PID_pos = {
+	.Kp_numerator = CONFIG_KP_NUMERATOR_FOR_POS,
+	.Kp_denominator = CONFIG_KP_DENOMINATOR_FOR_POS,
+
+	.Ki_numerator = 0,
+	.Ki_denominator = 1,
+
+	.Kd_numerator = 0,
+	.Kd_denominator = 1,
+
+	.i_temp = 0,
+	.d_temp = 0,
+
+	.i_min = -500,
+	.i_max = 500,
+};
+
+#define ERR_C(target_speed, actual_speed) (int32_t)(target_speed - actual_speed)
+
+static inline int32_t calculate_pid_from_error(int32_t error, struct PID_def *pid)
+{
+	int32_t P = ((int32_t)(((int32_t)pid->Kp_numerator * error) /
+				(int32_t)pid->Kp_denominator));
+	pid->i_temp = pid->i_temp + error;
+	if(pid->i_temp < pid->i_min) pid->i_temp = pid->i_min;
+	if(pid->i_temp < pid->i_max) pid->i_temp = pid->i_max;
+	int32_t I = ((int32_t)((int32_t)pid->Ki_numerator * pid->i_temp /
+			       (int32_t)pid->Ki_denominator));
+	int32_t D = ((int32_t)((int32_t)pid->Kd_numerator * (int32_t)(pid->d_temp - error) /
+			       (int32_t)pid->Kd_denominator));
+	pid->d_temp = error;
+	return P + I + D;
+}
+
+static inline int32_t calculate_pid(int32_t target_speed, int32_t actual_speed, struct PID_def *pid)
+{
+	return calculate_pid_from_error(ERR_C(target_speed, actual_speed), pid);
+}
 
 // Difference from target position and actual position
 #define CALC_POSITION_DELTA(chnl) \

--- a/BrushedMotorControllerFirmware/include/calculations.h
+++ b/BrushedMotorControllerFirmware/include/calculations.h
@@ -3,8 +3,8 @@
  * Copyright (c) 2024 Maciej Baczmanski, Jakub Mazur
  */
 
-#define FULL_SPIN_DEGREES (360u * CONFIG_POSITION_CONTROL_MODIFIER)
-#define HALF_SPIN_DEGREES (180u * CONFIG_POSITION_CONTROL_MODIFIER)
+#define DEGREES_PER_ROTATION (360u * CONFIG_POSITION_CONTROL_MODIFIER)
+#define DEGREES_PER_HALF_ROTATION (180u * CONFIG_POSITION_CONTROL_MODIFIER)
 
 struct PID_def {
 	const uint32_t Kp_numerator;
@@ -101,7 +101,7 @@ static inline int32_t calculate_pid(int32_t target_speed, int32_t actual_speed, 
 Unit replacement - interrupt counter to degrees
 */
 #define INTERRUPT_COUNT_TO_DEG_DIFF(diff) \
-	(int32_t)((diff*(int32_t)FULL_SPIN_DEGREES) /\
+	(int32_t)((diff*(int32_t)DEGREES_PER_ROTATION) /\
 	 (CONFIG_ENC_STEPS_PER_ROTATION * CONFIG_GEARSHIFT_RATIO))
 
 /*
@@ -117,5 +117,5 @@ Calculate new position (int32_t) based on:
 Wrap position to range 0-360 degree
 */
 #define WRAP_POS_TO_RANGE(new_pos) \
-	(uint32_t)((new_pos % (int32_t)FULL_SPIN_DEGREES) + \
-		   ((new_pos < 0) ? (int32_t)FULL_SPIN_DEGREES : 0))
+	(uint32_t)((new_pos % (int32_t)DEGREES_PER_ROTATION) + \
+		   ((new_pos < 0) ? (int32_t)DEGREES_PER_ROTATION : 0))

--- a/BrushedMotorControllerFirmware/include/calculations.h
+++ b/BrushedMotorControllerFirmware/include/calculations.h
@@ -93,16 +93,3 @@ static inline int32_t calculate_pid(int32_t target_speed, int32_t actual_speed, 
 {
 	return calculate_pid_from_error(ERR_C(target_speed, actual_speed), pid);
 }
-
-// Difference from target position and actual position
-#define CALC_POSITION_DELTA(chnl) \
-	drv_chnls[chnl].position_delta = drv_chnls[chnl].target_position - \
-					 drv_chnls[chnl].curr_pos; \
-	bool is_target_behind = false; \
-	if (drv_chnls[chnl].position_delta < 0) { \
-		drv_chnls[chnl].position_delta = \
-		-drv_chnls[chnl].position_delta; \
-		is_target_behind = true; \
-	} \
-// Check if motor should spin backward to get to the target
-// (if target is smalller number than current position)

--- a/BrushedMotorControllerFirmware/include/calculations.h
+++ b/BrushedMotorControllerFirmware/include/calculations.h
@@ -102,7 +102,7 @@ Unit replacement - interrupt counter to degrees
 */
 #define INTERRUPT_COUNT_TO_DEG_DIFF(diff) \
 	(int32_t)((diff*(int32_t)DEGREES_PER_ROTATION) /\
-	 (CONFIG_ENC_STEPS_PER_ROTATION * CONFIG_GEARSHIFT_RATIO))
+		  (CONFIG_ENC_STEPS_PER_ROTATION * CONFIG_GEARSHIFT_RATIO))
 
 /*
 Calculate new position (int32_t) based on:
@@ -110,8 +110,8 @@ Calculate new position (int32_t) based on:
 - position difference (in degrees, int32_t)
 - position difference modifier (int8_t, 1 or -1) - describes which way was the motor spinning
 */
-#define CALC_NEW_POS(pos_diff_in_deg, pos_diff_modifier, chnl) \
-	((int32_t)drv_chnls[chnl].curr_pos + pos_diff_modifier * pos_diff_in_deg)
+#define CALC_NEW_POS(pos_diff_in_deg, chnl) \
+	(int32_t)(((int32_t)drv_chnls[chnl].curr_pos) + pos_diff_in_deg)
 
 /*
 Wrap position to range 0-360 degree
@@ -119,3 +119,5 @@ Wrap position to range 0-360 degree
 #define WRAP_POS_TO_RANGE(new_pos) \
 	(uint32_t)((new_pos % (int32_t)DEGREES_PER_ROTATION) + \
 		   ((new_pos < 0) ? (int32_t)DEGREES_PER_ROTATION : 0))
+
+#define ABS(v) (v < 0 ? -v : v)

--- a/BrushedMotorControllerFirmware/include/calculations.h
+++ b/BrushedMotorControllerFirmware/include/calculations.h
@@ -74,8 +74,6 @@ struct PID_def PID_pos = {
 	.i_max = 500,
 };
 
-#define ERR_C(target_speed, actual_speed) (int32_t)(target_speed - actual_speed)
-
 static inline int32_t calculate_pid_from_error(int32_t error, struct PID_def *pid)
 {
 	int32_t P = ((int32_t)(((int32_t)pid->Kp_numerator * error) /
@@ -95,7 +93,7 @@ static inline int32_t calculate_pid_from_error(int32_t error, struct PID_def *pi
 
 static inline int32_t calculate_pid(int32_t target_speed, int32_t actual_speed, struct PID_def *pid)
 {
-	return calculate_pid_from_error(ERR_C(target_speed, actual_speed), pid);
+	return calculate_pid_from_error((int32_t)(target_speed - actual_speed), pid);
 }
 
 
@@ -114,5 +112,3 @@ static inline int32_t calculate_pid(int32_t target_speed, int32_t actual_speed, 
 #define WRAP_POS_TO_RANGE(new_pos) \
 	(uint32_t)((new_pos % (int32_t)DEGREES_PER_ROTATION) + \
 		   ((new_pos < 0) ? (int32_t)DEGREES_PER_ROTATION : 0))
-
-#define ABS(v) (v < 0 ? -v : v)

--- a/BrushedMotorControllerFirmware/include/calculations.h
+++ b/BrushedMotorControllerFirmware/include/calculations.h
@@ -81,8 +81,10 @@ static inline int32_t calculate_pid_from_error(int32_t error, struct PID_def *pi
 	int32_t P = ((int32_t)(((int32_t)pid->Kp_numerator * error) /
 				(int32_t)pid->Kp_denominator));
 	pid->i_temp = pid->i_temp + error;
-	if(pid->i_temp < pid->i_min) pid->i_temp = pid->i_min;
-	if(pid->i_temp < pid->i_max) pid->i_temp = pid->i_max;
+	if (pid->i_temp < pid->i_min)
+		pid->i_temp = pid->i_min;
+	if (pid->i_temp < pid->i_max)
+		pid->i_temp = pid->i_max;
 	int32_t I = ((int32_t)((int32_t)pid->Ki_numerator * pid->i_temp /
 			       (int32_t)pid->Ki_denominator));
 	int32_t D = ((int32_t)((int32_t)pid->Kd_numerator * (int32_t)(pid->d_temp - error) /
@@ -97,25 +99,18 @@ static inline int32_t calculate_pid(int32_t target_speed, int32_t actual_speed, 
 }
 
 
-/*
-Unit replacement - interrupt counter to degrees
-*/
+/// Unit replacement - interrupt counter to degrees
 #define INTERRUPT_COUNT_TO_DEG_DIFF(diff) \
 	(int32_t)((diff*(int32_t)DEGREES_PER_ROTATION) /\
 		  (CONFIG_ENC_STEPS_PER_ROTATION * CONFIG_GEARSHIFT_RATIO))
 
-/*
-Calculate new position (int32_t) based on:
-- previous position (drv_chnls[chnl].curr_pos, uint32_t)
-- position difference (in degrees, int32_t)
-- position difference modifier (int8_t, 1 or -1) - describes which way was the motor spinning
-*/
+/// Calculate new position (int32_t) based on:
+/// - previous position (drv_chnls[chnl].curr_pos, uint32_t)
+/// - position difference (in degrees, int32_t)
 #define CALC_NEW_POS(pos_diff_in_deg, chnl) \
 	(int32_t)(((int32_t)drv_chnls[chnl].curr_pos) + pos_diff_in_deg)
 
-/*
-Wrap position to range 0-360 degree
-*/
+/// Wrap position to range 0-360 degree
 #define WRAP_POS_TO_RANGE(new_pos) \
 	(uint32_t)((new_pos % (int32_t)DEGREES_PER_ROTATION) + \
 		   ((new_pos < 0) ? (int32_t)DEGREES_PER_ROTATION : 0))

--- a/BrushedMotorControllerFirmware/include/driver.c
+++ b/BrushedMotorControllerFirmware/include/driver.c
@@ -193,9 +193,10 @@ static void update_speed_and_position_continuous(struct k_work *work)
 				// increase or decrese speed each iteration by Kp * speed_delta
 				drv_chnls[chnl].speed_control =
 					(uint32_t)(drv_chnls[chnl].speed_control +
-						   CALC_SPEED_CONTROL(
+						   calculate_pid(
 							drv_chnls[chnl].target_speed_mrpm,
-							drv_chnls[chnl].actual_mrpm
+							drv_chnls[chnl].actual_mrpm,
+							&PID_spd
 						   )
 						  );
 
@@ -244,9 +245,9 @@ static void update_speed_and_position_continuous(struct k_work *work)
 				} else {
 				// Calculate target speed based on the distance from the
 				// target position
+					int32_t temp = calculate_pid_from_error(delta_shortest_path, &PID_pos);
 					drv_chnls[chnl].target_speed_for_pos_cntrl =
-						CONFIG_KP_NUMERATOR_FOR_POS * delta_shortest_path /
-						CONFIG_KP_DENOMINATOR_FOR_POS;
+						(uint32_t)(temp >=0 ? temp : 0u);
 
 					if (drv_chnls[chnl].target_speed_for_pos_cntrl <
 					    MINIMUM_SPEED) {
@@ -268,9 +269,10 @@ static void update_speed_and_position_continuous(struct k_work *work)
 						// or distance has changed
 						drv_chnls[chnl].target_speed_mrpm =
 						    drv_chnls[chnl].target_speed_mrpm +
-						    CALC_SPEED_CONTROL_FOR_POS(
+						    calculate_pid(
 							 drv_chnls[chnl].target_speed_for_pos_cntrl,
-							 drv_chnls[chnl].actual_mrpm
+							 drv_chnls[chnl].actual_mrpm,
+							 &PID_spd_for_pos
 						    );
 #if !defined(CONFIG_POS_SOFT_START)
 					}

--- a/BrushedMotorControllerFirmware/include/driver.c
+++ b/BrushedMotorControllerFirmware/include/driver.c
@@ -123,7 +123,7 @@ static inline void calculate_pos_delta(enum ChannelNumber chnl, bool *is_target_
 	if (drv_chnls[chnl].position_delta < 0) {
 		drv_chnls[chnl].position_delta =
 		-drv_chnls[chnl].position_delta;
-		if(is_target_behind != NULL)
+		if (is_target_behind != NULL)
 			*is_target_behind = true;
 	}
 }
@@ -194,9 +194,9 @@ static void update_speed_and_position_continuous(struct k_work *work)
 				ret = speed_pwm_set(drv_chnls[chnl].speed_control, chnl);
 			} else if (control_mode == POSITION) {
 				bool is_target_behind = false;
-				calculate_pos_delta(chnl, &is_target_behind);
-
 				uint32_t delta_shortest_path = 0;
+
+				calculate_pos_delta(chnl, &is_target_behind);
 
 				// Set proper spinning direction
 				if (drv_chnls[chnl].position_delta < DEGREES_PER_HALF_ROTATION) {
@@ -227,9 +227,11 @@ static void update_speed_and_position_continuous(struct k_work *work)
 				} else {
 				// Calculate target speed based on the distance from the
 				// target position
-					int32_t temp = calculate_pid_from_error(delta_shortest_path, &PID_pos);
+					int32_t temp = calculate_pid_from_error(delta_shortest_path,
+										&PID_pos);
+
 					drv_chnls[chnl].target_speed_for_pos_cntrl =
-						(uint32_t)(temp >=0 ? temp : 0u);
+						(uint32_t)(temp >= 0 ? temp : 0u);
 
 					if (drv_chnls[chnl].target_speed_for_pos_cntrl <
 					    MINIMUM_SPEED) {

--- a/BrushedMotorControllerFirmware/include/driver.c
+++ b/BrushedMotorControllerFirmware/include/driver.c
@@ -5,6 +5,7 @@
 #include <zephyr/drivers/pwm.h>
 #include <zephyr/types.h>
 #include <string.h>
+#include <stdlib.h>
 #include "return_codes.h"
 #include "driver.h"
 
@@ -162,7 +163,7 @@ static void update_speed_and_position_continuous(struct k_work *work)
 						);
 
 		// calculate actual speed
-		drv_chnls[chnl].actual_mrpm = RPM_TO_MRPM * MIN_TO_MS * ((uint64_t)ABS(diff)) /
+		drv_chnls[chnl].actual_mrpm = RPM_TO_MRPM * MIN_TO_MS * ((uint64_t)llabs(diff)) /
 			(CONFIG_ENC_STEPS_PER_ROTATION *
 			CONFIG_GEARSHIFT_RATIO *
 			CONFIG_ENC_TIMER_PERIOD_MS);

--- a/BrushedMotorControllerFirmware/include/driver.c
+++ b/BrushedMotorControllerFirmware/include/driver.c
@@ -246,6 +246,11 @@ static void update_speed_and_position_continuous(struct k_work *work)
 						CONFIG_KP_NUMERATOR_FOR_POS * delta_shortest_path /
 						CONFIG_KP_DENOMINATOR_FOR_POS;
 
+					if (drv_chnls[chnl].target_speed_for_pos_cntrl < MINIMUM_SPEED) {
+						drv_chnls[chnl].target_speed_for_pos_cntrl =
+							MINIMUM_SPEED;
+					}
+
 					drv_chnls[chnl].target_speed_mrpm =
 						drv_chnls[chnl].target_speed_mrpm +
 						CALC_SPEED_CONTROL_FOR_POS(
@@ -254,13 +259,11 @@ static void update_speed_and_position_continuous(struct k_work *work)
 						);
 
 					if (drv_chnls[chnl].target_speed_mrpm < MINIMUM_SPEED) {
-
 						drv_chnls[chnl].target_speed_mrpm =
 							MINIMUM_SPEED;
 					}
 
 					if (drv_chnls[chnl].target_speed_mrpm > CONFIG_SPEED_MAX_MRPM) {
-
 						drv_chnls[chnl].target_speed_mrpm =
 							CONFIG_SPEED_MAX_MRPM;
 					}

--- a/BrushedMotorControllerFirmware/include/driver.c
+++ b/BrushedMotorControllerFirmware/include/driver.c
@@ -301,21 +301,21 @@ bool is_target_achieved(enum ChannelNumber chnl)
 					drv_chnls[chnl].position_delta);
 	}
 
-	if (drv_chnls[chnl].target_achieved) {
-		if (delta_shortest_path <=
-			(DEGREES_PER_ROTATION) / (CONFIG_POS_CONTROL_PRECISION_MODIFIER)) {
-			return true;
-		}
-	} else {
-		if (delta_shortest_path <=
-		   ((DEGREES_PER_ROTATION * CONFIG_POS_CONTROL_HISTERESIS_PERCENTAGE) /
-		    (CONFIG_POS_CONTROL_PRECISION_MODIFIER * 100))) {
+	// Range with histeresis is narrower by some percentage, so it can be checked first
+	if (delta_shortest_path <=
+		((DEGREES_PER_ROTATION * CONFIG_POS_CONTROL_HISTERESIS_PERCENTAGE) /
+		(CONFIG_POS_CONTROL_PRECISION_MODIFIER * 100))) {
 
-			return true;
-		}
+		return true;
 	}
 
-
+	// Ring between range with histeresis (narrower) and regular range (wider) is accepted only
+	// if target was already previously achieved!
+	if (drv_chnls[chnl].target_achieved &&
+	    (delta_shortest_path <=
+			(DEGREES_PER_ROTATION) / (CONFIG_POS_CONTROL_PRECISION_MODIFIER))) {
+		return true;
+	}
 
 	return false;
 }

--- a/BrushedMotorControllerFirmware/include/driver.c
+++ b/BrushedMotorControllerFirmware/include/driver.c
@@ -258,6 +258,12 @@ static void update_speed_and_position_continuous(struct k_work *work)
 						drv_chnls[chnl].target_speed_mrpm =
 							MINIMUM_SPEED;
 					}
+
+					if (drv_chnls[chnl].target_speed_mrpm > CONFIG_SPEED_MAX_MRPM) {
+
+						drv_chnls[chnl].target_speed_mrpm =
+							CONFIG_SPEED_MAX_MRPM;
+					}
 				}
 
 				ret_debug =
@@ -664,12 +670,12 @@ return_codes_t get_control_mode_as_string(enum ControlModes control_mode, char *
 #pragma region DebugFunctions
 uint64_t get_cycles_count_DEBUG(void)
 {
-	return drv_chnls[CH0].count_cycles_fwd;
+	return drv_chnls[CH1].target_speed_for_pos_cntrl;
 }
 
 uint64_t get_time_cycles_count_DEBUG(void)
 {
-	return count_timer;
+	return drv_chnls[CH1].target_speed_mrpm;
 }
 
 int32_t get_ret_DEBUG(void)
@@ -679,17 +685,17 @@ int32_t get_ret_DEBUG(void)
 
 uint32_t get_calc_speed_DEBUG(void)
 {
-	return drv_chnls[CH0].speed_control;
+	return drv_chnls[CH1].speed_control;
 }
 
 uint32_t get_target_pos_DEBUG(void)
 {
-	return drv_chnls[CH0].target_position;
+	return drv_chnls[CH1].target_position;
 }
 
 int32_t get_pos_d_DEBUG(void)
 {
-	return drv_chnls[CH0].position_delta;
+	return drv_chnls[CH1].position_delta;
 }
 #pragma endregion DebugFunctions
 

--- a/BrushedMotorControllerFirmware/include/driver.c
+++ b/BrushedMotorControllerFirmware/include/driver.c
@@ -656,20 +656,6 @@ return_codes_t position_reset_zero(enum ChannelNumber chnl)
 	return SUCCESS;
 }
 
-return_codes_t get_control_mode_as_string(enum ControlModes control_mode, char **ret_value)
-{
-	static const char * const modes_names[] = {
-		[SPEED] = "Speed",
-		[POSITION] = "Position"
-	};
-
-	// TODO - add some range check
-
-	*ret_value = modes_names[control_mode];
-
-	return SUCCESS;
-}
-
 #pragma region DebugFunctions
 uint64_t get_cycles_count_DEBUG(void)
 {

--- a/BrushedMotorControllerFirmware/include/driver.c
+++ b/BrushedMotorControllerFirmware/include/driver.c
@@ -176,7 +176,7 @@ static void update_speed_and_position_continuous(struct k_work *work)
 			drv_chnls[chnl].actual_dir = STOPPED;
 		}
 
-		int32_t pos_diff = (diff*FULL_SPIN_DEGREES) /
+		int32_t pos_diff = (diff*DEGREES_PER_ROTATION) /
 				   (CONFIG_ENC_STEPS_PER_ROTATION * CONFIG_GEARSHIFT_RATIO);
 
 		// calculate actual position
@@ -187,7 +187,7 @@ static void update_speed_and_position_continuous(struct k_work *work)
 							chnl)
 						);
 
-		if (drv_chnls[chnl].curr_pos == FULL_SPIN_DEGREES) {
+		if (drv_chnls[chnl].curr_pos == DEGREES_PER_ROTATION) {
 			// TODO - why this doesn't work? 360 still appears sometimes!
 			drv_chnls[chnl].curr_pos = 0u;
 		}
@@ -230,7 +230,7 @@ static void update_speed_and_position_continuous(struct k_work *work)
 				uint32_t delta_shortest_path = 0;
 
 				// Set proper spinning direction
-				if (drv_chnls[chnl].position_delta < HALF_SPIN_DEGREES) {
+				if (drv_chnls[chnl].position_delta < DEGREES_PER_HALF_ROTATION) {
 					// If target is closer that 180 degree
 
 					if (!is_target_behind)
@@ -245,7 +245,7 @@ static void update_speed_and_position_continuous(struct k_work *work)
 					else
 						set_direction_raw(FORWARD, chnl);
 
-					delta_shortest_path = FULL_SPIN_DEGREES -
+					delta_shortest_path = DEGREES_PER_ROTATION -
 							      drv_chnls[chnl].position_delta;
 				}
 
@@ -325,21 +325,21 @@ bool is_target_achieved(enum ChannelNumber chnl)
 
 	calculate_pos_delta(chnl, NULL);
 
-	if (drv_chnls[chnl].position_delta < HALF_SPIN_DEGREES) {
+	if (drv_chnls[chnl].position_delta < DEGREES_PER_HALF_ROTATION) {
 		delta_shortest_path = drv_chnls[chnl].position_delta;
 	} else {
-		delta_shortest_path = ((int32_t)FULL_SPIN_DEGREES -
+		delta_shortest_path = ((int32_t)DEGREES_PER_ROTATION -
 					drv_chnls[chnl].position_delta);
 	}
 
 	if (drv_chnls[chnl].target_achieved) {
 		if (delta_shortest_path <=
-			(FULL_SPIN_DEGREES) / (CONFIG_POS_CONTROL_PRECISION_MODIFIER)) {
+			(DEGREES_PER_ROTATION) / (CONFIG_POS_CONTROL_PRECISION_MODIFIER)) {
 			return true;
 		}
 	} else {
 		if (delta_shortest_path <=
-		   ((FULL_SPIN_DEGREES * CONFIG_POS_CONTROL_HISTERESIS_PERCENTAGE) /
+		   ((DEGREES_PER_ROTATION * CONFIG_POS_CONTROL_HISTERESIS_PERCENTAGE) /
 		    (CONFIG_POS_CONTROL_PRECISION_MODIFIER * 100))) {
 
 			return true;
@@ -641,7 +641,7 @@ return_codes_t position_get(uint32_t *value, enum ChannelNumber chnl)
 		return ERR_NOT_INITIALISED;
 	}
 
-	if (drv_chnls[chnl].curr_pos == FULL_SPIN_DEGREES) {
+	if (drv_chnls[chnl].curr_pos == DEGREES_PER_ROTATION) {
 		// TODO - remove this when continuus update will treat 360 as 0 as it should!
 		*value = 0u;
 		return SUCCESS;

--- a/BrushedMotorControllerFirmware/include/driver.h
+++ b/BrushedMotorControllerFirmware/include/driver.h
@@ -21,6 +21,11 @@ enum ControlModes {
 	POSITION
 };
 
+static const char * const modes_names[] = {
+	[SPEED] = "Speed",
+	[POSITION] = "Position"
+};
+
 /// @brief struct representing current software version
 struct DriverVersion {
 	uint8_t major;

--- a/BrushedMotorControllerFirmware/include/driver.h
+++ b/BrushedMotorControllerFirmware/include/driver.h
@@ -21,7 +21,7 @@ enum ControlModes {
 	POSITION
 };
 
-static const char * const modes_names[] = {
+static const char * const mode_names[] = {
 	[SPEED] = "Speed",
 	[POSITION] = "Position"
 };

--- a/BrushedMotorControllerFirmware/include/uart_shell/shell_mode_control.c
+++ b/BrushedMotorControllerFirmware/include/uart_shell/shell_mode_control.c
@@ -17,7 +17,7 @@ static int cmd_mode(const struct shell *shell, size_t argc, char *argv[])
 		ret = mode_get(&mode);
 		switch (ret) {
 		case (SUCCESS):
-			shell_fprintf(shell, SHELL_NORMAL, "mode: %s\n", modes_names[mode]);
+			shell_fprintf(shell, SHELL_NORMAL, "mode: %s\n", mode_names[mode]);
 
 		break;
 		case (ERR_NOT_INITIALISED):

--- a/BrushedMotorControllerFirmware/include/uart_shell/shell_mode_control.c
+++ b/BrushedMotorControllerFirmware/include/uart_shell/shell_mode_control.c
@@ -17,17 +17,8 @@ static int cmd_mode(const struct shell *shell, size_t argc, char *argv[])
 		ret = mode_get(&mode);
 		switch (ret) {
 		case (SUCCESS):
-			char *mode_as_str = "";
-			int r = get_control_mode_as_string(mode, &mode_as_str);
+			shell_fprintf(shell, SHELL_NORMAL, "mode: %s\n", modes_names[mode]);
 
-			if (r == SUCCESS) {
-				shell_fprintf(shell, SHELL_NORMAL, "mode: %s\n", mode_as_str);
-
-			} else {
-				shell_fprintf(shell, SHELL_ERROR,
-				"Conversion error, code: %d\n", ret);
-
-			}
 		break;
 		case (ERR_NOT_INITIALISED):
 			shell_fprintf(shell, SHELL_ERROR,


### PR DESCRIPTION
1. Bugfix: Speed control for position control - lock to desired range
2. Feature: Immediate start or soft start setting added
3. Feature: PID refactor - I and D parts added
4. Cleaup: Position calculation macro turned into inline function and cleaned up
5. Cleanup: Degrees per rotation rename
6. Cleanup: Precise encoder interrupts counter modified
7. Cleanup: `is_target_achieved` function minor if-checks optimization
8. Cleanup: `get_control_mode_as_string` removed, as it was unnecessary wrapper for const array